### PR TITLE
fixed username argument to upload

### DIFF
--- a/spot_connect/instance_methods.py
+++ b/spot_connect/instance_methods.py
@@ -104,7 +104,7 @@ def upload_to_ec2(instance, user_name, files, remote_dir='.', kp_dir=None, verbo
     if kp_dir is None: 
         kp_dir = sutils.get_default_kp_dir()
 
-    client = ec2_methods.connect_to_instance(instance['PublicIpAddress'],kp_dir+'/'+instance['KeyName'],username='ec2-user',port=22)
+    client = ec2_methods.connect_to_instance(instance['PublicIpAddress'],kp_dir+'/'+instance['KeyName'],username=user_name,port=22)
     if verbose:
         print('Connected. Uploading files...')
     stfp = client.open_sftp()


### PR DESCRIPTION
username argument in function "connect_to_instance" called in "upload_to_ec2" was set equal to "ec2-user", not taking into account username defined in profile config.