### PR TITLE
Fix: parse filename for data files on macOS

### DIFF
--- a/spot_connect/instance_methods.py
+++ b/spot_connect/instance_methods.py
@@ -12,7 +12,7 @@ the instance.
 MIT License 2020
 """
 
-import sys, boto3 
+import sys, boto3, os
 from spot_connect import ec2_methods, sutils, interactive
 
 def run_script(instance, user_name, script, cmd=False, port=22, kp_dir=None, return_output=False):
@@ -112,8 +112,8 @@ def upload_to_ec2(instance, user_name, files, remote_dir='.', kp_dir=None, verbo
     try: 
     	for f in files: 
             if verbose:
-                print('Uploading %s' % str(f.split('\\')[-1]))
-            stfp.put(f, remote_dir+'/'+f.split('\\')[-1], callback=sutils.printTotals, confirm=True)
+                print('Uploading %s' % str(os.path.split(f)[-1]))
+            stfp.put(f, os.path.join(remote_dir, os.path.split(f)[-1]), callback=sutils.printTotals, confirm=True)
 
     except Exception as e:
         raise e

--- a/spot_connect/instance_methods.py
+++ b/spot_connect/instance_methods.py
@@ -104,7 +104,7 @@ def upload_to_ec2(instance, user_name, files, remote_dir='.', kp_dir=None, verbo
     if kp_dir is None: 
         kp_dir = sutils.get_default_kp_dir()
 
-    client = ec2_methods.connect_to_instance(instance['PublicIpAddress'],kp_dir+'/'+instance['KeyName'],username='ec2-user',port=22)
+    client = ec2_methods.connect_to_instance(instance['PublicIpAddress'],kp_dir+'/'+instance['KeyName'],username=user_name,port=22)
     if verbose:
         print('Connected. Uploading files...')
     stfp = client.open_sftp()

--- a/spot_connect/spotted.py
+++ b/spot_connect/spotted.py
@@ -304,7 +304,7 @@ class SpotInstance:
             scripts=[scripts]
         elif type(scripts)!=list:
             raise TypeError('scripts must be string or list of strings')
-        
+        output = ''
         for script in scripts:
             if not cmd:
                 print('\nExecuting script "%s"...' % str(script))

--- a/spot_connect/sutils.py
+++ b/spot_connect/sutils.py
@@ -57,7 +57,7 @@ def pull_root():
 def load_profiles():
     '''Load the profiles from the package profile.txt file'''
     
-    profile = [f for f in list(absoluteFilePaths(pull_root()+'/data/')) if f.split('\\')[-1]=='profiles.txt'][0]    
+    profile = [f for f in list(absoluteFilePaths(os.path.join(pull_root(),'data'))) if os.path.split(f)[-1]=='profiles.txt'][0]    
     
     with open(profile,'r') as f:
         profiles = ast.literal_eval(f.read())
@@ -68,7 +68,7 @@ def load_profiles():
 
 def save_profiles(profiles):
     '''Save the profile dict str in a .txt file'''
-    profile_file = [f for f in list(absoluteFilePaths(pull_root()+'/data/')) if f.split('\\')[-1]=='profiles.txt'][0]    
+    profile_file = [f for f in list(absoluteFilePaths(os.path.join(pull_root(),'data'))) if os.path.split(f)[-1]=='profiles.txt'][0]    
     
     #ptosave = ast.literal_eval(profile_str)
     print(profile_file)
@@ -122,7 +122,7 @@ def printTotals(transferred, toBeTransferred):
 
 def get_package_kp_dir():
     '''Get the key-pair directory'''
-    kpfile = [f for f in list(absoluteFilePaths(pull_root()+'/data/')) if f.split('\\')[-1]=='key_pair_default_dir.txt'][0]    
+    kpfile = [f for f in list(absoluteFilePaths(os.path.join(pull_root(),'data'))) if os.path.split(f)[-1]=='key_pair_default_dir.txt'][0]    
     with open(kpfile,'r') as f: 
         default_path = f.read()
         f.close()
@@ -135,7 +135,7 @@ def get_default_kp_dir():
 
 def set_default_kp_dir(directory : str): 
     '''Set the default key pair directory'''
-    kpfile = [f for f in list(absoluteFilePaths(pull_root()+'/data/')) if f.split('\\')[-1]=='key_pair_default_dir.txt'][0]    
+    kpfile = [f for f in list(absoluteFilePaths(os.path.join(pull_root(),'data'))) if os.path.split(f)[-1]=='key_pair_default_dir.txt'][0]    
     with open(kpfile,'w') as f: 
         f.write(directory)
         f.close()
@@ -236,7 +236,7 @@ def split_workloads(n_jobs, workload, wrkdir=None, filename=None):
     '''    
     
     if wrkdir is None: 
-        wrkdir = pull_root()+'/data/'
+        wrkdir = os.path.join(pull_root(),'data')
         if not os.path.exists(wrkdir): 
             try: 
                 os.mkdir(wrkdir)
@@ -285,7 +285,7 @@ class CurrentIdLog:
         date = datetime.today().date()
         
         if logdir is None: 
-            self.hd=pull_root()+'/data/'
+            self.hd=os.path.join(pull_root(),'data')
         else: 
             self.hd=logdir
         


### PR DESCRIPTION
Issue: Failing to load profile data using load_profiles() on macOS. The code resulted in an 'index out of bounds' error, as it failed to correctly retrieve the filename from the generated absolute path. 
This fixes the issue using the 'os' module to generate/parse file paths.